### PR TITLE
Add SQLAlchemy models and JWT auth with role-based access

### DIFF
--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -1,0 +1,48 @@
+from datetime import datetime, timedelta
+from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi.security import OAuth2PasswordRequestForm
+from jose import jwt
+from passlib.context import CryptContext
+from sqlalchemy.orm import Session
+from .config import settings
+from .dependencies import get_db
+from .models import User
+
+
+router = APIRouter(prefix="/auth", tags=["auth"])
+
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+
+def verify_password(plain_password: str, hashed_password: str) -> bool:
+    return pwd_context.verify(plain_password, hashed_password)
+
+
+def get_password_hash(password: str) -> str:
+    return pwd_context.hash(password)
+
+
+def authenticate_user(db: Session, username: str, password: str) -> User | None:
+    user = db.query(User).filter(User.username == username).first()
+    if not user or not verify_password(password, user.hashed_password):
+        return None
+    return user
+
+
+def create_access_token(data: dict, expires_delta: timedelta | None = None) -> str:
+    to_encode = data.copy()
+    expire = datetime.utcnow() + (expires_delta or timedelta(minutes=30))
+    to_encode.update({"exp": expire})
+    return jwt.encode(to_encode, settings.secret_key, algorithm="HS256")
+
+
+@router.post("/token")
+def login_for_access_token(
+    form_data: OAuth2PasswordRequestForm = Depends(),
+    db: Session = Depends(get_db),
+):
+    user = authenticate_user(db, form_data.username, form_data.password)
+    if not user:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Incorrect username or password")
+    access_token = create_access_token({"sub": user.username})
+    return {"access_token": access_token, "token_type": "bearer"}

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -1,0 +1,14 @@
+from pydantic import BaseSettings
+
+
+class Settings(BaseSettings):
+    """Application settings loaded from the environment."""
+
+    database_url: str
+    secret_key: str
+
+    class Config:
+        env_file = ".env"
+
+
+settings = Settings()

--- a/backend/app/dependencies.py
+++ b/backend/app/dependencies.py
@@ -1,0 +1,44 @@
+from fastapi import Depends, HTTPException, status
+from fastapi.security import OAuth2PasswordBearer
+from jose import JWTError, jwt
+from sqlalchemy.orm import Session
+from .config import settings
+from .models import SessionLocal, User, RoleEnum
+
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/auth/token")
+
+
+def get_db() -> Session:
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+def get_current_user(token: str = Depends(oauth2_scheme), db: Session = Depends(get_db)) -> User:
+    credentials_exception = HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Could not validate credentials",
+        headers={"WWW-Authenticate": "Bearer"},
+    )
+    try:
+        payload = jwt.decode(token, settings.secret_key, algorithms=["HS256"])
+        username: str | None = payload.get("sub")
+        if username is None:
+            raise credentials_exception
+    except JWTError:
+        raise credentials_exception
+    user = db.query(User).filter(User.username == username).first()
+    if user is None:
+        raise credentials_exception
+    return user
+
+
+def require_role(*roles: RoleEnum):
+    def role_dependency(current_user: User = Depends(get_current_user)) -> User:
+        if current_user.role is None or current_user.role.name not in [r.value for r in roles]:
+            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Not enough permissions")
+        return current_user
+
+    return role_dependency

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,20 +1,14 @@
 from fastapi import FastAPI
-from pydantic import BaseSettings
+from .models import Base, engine
+from .auth import router as auth_router
+from .users import role_router, user_router
 
-
-class Settings(BaseSettings):
-    """Application settings loaded from the environment."""
-
-    database_url: str
-    secret_key: str
-
-    class Config:
-        env_file = ".env"
-
-
-settings = Settings()
+Base.metadata.create_all(bind=engine)
 
 app = FastAPI()
+app.include_router(auth_router)
+app.include_router(user_router)
+app.include_router(role_router)
 
 
 @app.get("/health")

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,0 +1,37 @@
+from enum import Enum
+from sqlalchemy import Column, Enum as SqlEnum, ForeignKey, Integer, String, create_engine
+from sqlalchemy.orm import declarative_base, relationship, sessionmaker
+from .config import settings
+
+
+Base = declarative_base()
+
+
+class RoleEnum(str, Enum):
+    world_builder = "world_builder"
+    dungeon_master = "dungeon_master"
+    player = "player"
+
+
+class Role(Base):
+    __tablename__ = "roles"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(SqlEnum(RoleEnum), unique=True, nullable=False)
+
+    users = relationship("User", back_populates="role")
+
+
+class User(Base):
+    __tablename__ = "users"
+
+    id = Column(Integer, primary_key=True, index=True)
+    username = Column(String, unique=True, index=True, nullable=False)
+    hashed_password = Column(String, nullable=False)
+    role_id = Column(Integer, ForeignKey("roles.id"))
+
+    role = relationship("Role", back_populates="users")
+
+
+engine = create_engine(settings.database_url)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)

--- a/backend/app/users.py
+++ b/backend/app/users.py
@@ -1,0 +1,68 @@
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+from .auth import get_password_hash
+from .dependencies import get_db, require_role
+from .models import Role, RoleEnum, User
+
+
+class UserCreate(BaseModel):
+    username: str
+    password: str
+    role: RoleEnum
+
+
+class UserRead(BaseModel):
+    id: int
+    username: str
+    role: RoleEnum
+
+    class Config:
+        orm_mode = True
+
+
+class RoleCreate(BaseModel):
+    name: RoleEnum
+
+
+class RoleRead(BaseModel):
+    id: int
+    name: RoleEnum
+
+    class Config:
+        orm_mode = True
+
+
+user_router = APIRouter(prefix="/users", tags=["users"], dependencies=[Depends(require_role(RoleEnum.world_builder, RoleEnum.dungeon_master))])
+role_router = APIRouter(prefix="/roles", tags=["roles"], dependencies=[Depends(require_role(RoleEnum.world_builder))])
+
+
+@user_router.post("/", response_model=UserRead)
+def create_user(user: UserCreate, db: Session = Depends(get_db)):
+    db_role = db.query(Role).filter(Role.name == user.role).first()
+    if not db_role:
+        raise HTTPException(status_code=400, detail="Role not found")
+    db_user = User(username=user.username, hashed_password=get_password_hash(user.password), role=db_role)
+    db.add(db_user)
+    db.commit()
+    db.refresh(db_user)
+    return db_user
+
+
+@user_router.get("/", response_model=list[UserRead])
+def list_users(db: Session = Depends(get_db)):
+    return db.query(User).all()
+
+
+@role_router.post("/", response_model=RoleRead)
+def create_role(role: RoleCreate, db: Session = Depends(get_db)):
+    db_role = Role(name=role.name)
+    db.add(db_role)
+    db.commit()
+    db.refresh(db_role)
+    return db_role
+
+
+@role_router.get("/", response_model=list[RoleRead], dependencies=[])
+def list_roles(db: Session = Depends(get_db)):
+    return db.query(Role).all()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,4 +11,8 @@ dependencies = [
     "fastapi>=0.110.0",
     "uvicorn[standard]>=0.29.0",
     "python-dotenv>=1.0.1",
+    "sqlalchemy>=2.0.0",
+    "python-jose>=3.3.0",
+    "passlib[bcrypt]>=1.7.4",
+    "python-multipart>=0.0.6",
 ]


### PR DESCRIPTION
## Summary
- define SQLAlchemy models for `User` and `Role`
- add JWT login endpoint and password utilities
- implement role-based dependencies and CRUD APIs for users and roles

## Testing
- `python -m py_compile backend/app/*.py`
- `pytest` *(fails: no tests ran)*
- `pip install sqlalchemy python-jose 'passlib[bcrypt]' python-multipart` *(fails: Could not find a version that satisfies the requirement sqlalchemy)*

------
https://chatgpt.com/codex/tasks/task_e_689f9ccd2e6c832eb583a2d41f84c4d1