### PR TITLE
Add database session and Alembic migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,12 @@
 # metamorphosis
-Repository for web-based D&amp;D game.
+Repository for web-based D&D game.
+
+## Database Migrations
+
+Alembic is used for database schema migrations. To apply migrations run:
+
+```
+alembic -c backend/alembic.ini upgrade head
+```
+
+This command will create or update the database schema to the latest version.

--- a/backend/alembic.ini
+++ b/backend/alembic.ini
@@ -1,0 +1,35 @@
+[alembic]
+script_location = backend/alembic
+sqlalchemy.url = sqlite:///./test.db
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s

--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -1,0 +1,58 @@
+from logging.config import fileConfig
+import os
+import sys
+
+from alembic import context
+
+# Add app directory to path
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from app.db import engine
+from app.models import Base
+
+# this is the Alembic Config object, which provides
+# access to the values within the .ini file in use.
+config = context.config
+
+# Interpret the config file for Python logging.
+# This line sets up loggers basically.
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+# add your model's MetaData object here
+# for 'autogenerate' support
+# from myapp import mymodel
+# target_metadata = mymodel.Base.metadata
+# target_metadata = None
+target_metadata = Base.metadata
+
+
+def run_migrations_offline() -> None:
+    """Run migrations in 'offline' mode."""
+
+    url = engine.url.render_as_string(hide_password=False)
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    """Run migrations in 'online' mode."""
+
+    with engine.connect() as connection:
+        context.configure(connection=connection, target_metadata=target_metadata)
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/backend/alembic/versions/0001_initial.py
+++ b/backend/alembic/versions/0001_initial.py
@@ -1,0 +1,58 @@
+"""initial tables
+
+Revision ID: 0001
+Revises: 
+Create Date: 2024-05-27
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '0001'
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'roles',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('name', sa.Enum('world_builder', 'dungeon_master', 'player', name='roleenum'), nullable=False, unique=True),
+    )
+    op.create_table(
+        'users',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('username', sa.String(), nullable=False, unique=True),
+        sa.Column('hashed_password', sa.String(), nullable=False),
+        sa.Column('role_id', sa.Integer(), sa.ForeignKey('roles.id')),
+    )
+    op.create_table(
+        'sessions',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('user_id', sa.Integer(), sa.ForeignKey('users.id'), nullable=False),
+        sa.Column('token', sa.String(), nullable=False, unique=True),
+    )
+    op.create_table(
+        'world_items',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('name', sa.String(), nullable=False),
+        sa.Column('description', sa.String()),
+    )
+    op.create_table(
+        'player_profiles',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('user_id', sa.Integer(), sa.ForeignKey('users.id'), nullable=False),
+        sa.Column('bio', sa.String()),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table('player_profiles')
+    op.drop_table('world_items')
+    op.drop_table('sessions')
+    op.drop_table('users')
+    op.drop_table('roles')
+    sa.Enum('world_builder', 'dungeon_master', 'player', name='roleenum').drop(op.get_bind(), checkfirst=False)

--- a/backend/app/db.py
+++ b/backend/app/db.py
@@ -1,0 +1,7 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from .config import settings
+
+engine = create_engine(settings.database_url)
+SessionLocal = sessionmaker(bind=engine, autocommit=False, autoflush=False)

--- a/backend/app/dependencies.py
+++ b/backend/app/dependencies.py
@@ -3,7 +3,8 @@ from fastapi.security import OAuth2PasswordBearer
 from jose import JWTError, jwt
 from sqlalchemy.orm import Session
 from .config import settings
-from .models import SessionLocal, User, RoleEnum
+from .db import SessionLocal
+from .models import User, RoleEnum
 
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/auth/token")
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,5 +1,6 @@
 from fastapi import FastAPI
-from .models import Base, engine
+from .db import engine
+from .models import Base
 from .auth import router as auth_router
 from .users import role_router, user_router
 

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,7 +1,6 @@
 from enum import Enum
-from sqlalchemy import Column, Enum as SqlEnum, ForeignKey, Integer, String, create_engine
-from sqlalchemy.orm import declarative_base, relationship, sessionmaker
-from .config import settings
+from sqlalchemy import Column, Enum as SqlEnum, ForeignKey, Integer, String
+from sqlalchemy.orm import declarative_base, relationship
 
 
 Base = declarative_base()
@@ -29,9 +28,34 @@ class User(Base):
     username = Column(String, unique=True, index=True, nullable=False)
     hashed_password = Column(String, nullable=False)
     role_id = Column(Integer, ForeignKey("roles.id"))
-
     role = relationship("Role", back_populates="users")
+    sessions = relationship("Session", back_populates="user")
+    profile = relationship("PlayerProfile", back_populates="user", uselist=False)
 
 
-engine = create_engine(settings.database_url)
-SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+class Session(Base):
+    __tablename__ = "sessions"
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=False)
+    token = Column(String, unique=True, nullable=False)
+
+    user = relationship("User", back_populates="sessions")
+
+
+class WorldItem(Base):
+    __tablename__ = "world_items"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String, nullable=False)
+    description = Column(String)
+
+
+class PlayerProfile(Base):
+    __tablename__ = "player_profiles"
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=False)
+    bio = Column(String)
+
+    user = relationship("User", back_populates="profile")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "uvicorn[standard]>=0.29.0",
     "python-dotenv>=1.0.1",
     "sqlalchemy>=2.0.0",
+    "alembic>=1.13.0",
     "python-jose>=3.3.0",
     "passlib[bcrypt]>=1.7.4",
     "python-multipart>=0.0.6",


### PR DESCRIPTION
## Summary
- add SQLAlchemy engine and session factory
- introduce Alembic configuration with initial schema migration
- document running migrations in README

## Testing
- `pytest`
- `alembic -c backend/alembic.ini upgrade head` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f9f4b2bec832eb6be98e365975167